### PR TITLE
Remove dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ skip-string-normalization = true
 exclude='''
 (
     src/show_dialog/ui/forms
-  | \.venv.*
-  | \venv.*
+  | .venv.*
+  | venv.*
 )
 '''
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,13 @@ readme = 'README.md'
 authors = [{name = 'Joao Coelho'}]
 license = {file = 'LICENSE'}
 dependencies = ['pytest>=7.0.0']
+# https://pypi.org/pypi?%3Aaction=list_classifiers
 classifiers = [
-    "License :: OSI Approved :: MIT License",
-    "Framework :: Pytest" ,
+    'License :: OSI Approved :: MIT License',
+    'Framework :: Pytest',
+    'Intended Audience :: Developers',
+    'Programming Language :: Python',
+    'Development Status :: 5 - Production/Stable'
 ]
 
 [project.urls]

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -3,7 +3,6 @@
 # Dev tools
 invoke              # Tasks
 pip-tools           # Package management
-semantic-version    # Semantic versioning, more useful than `packaging.version`
 
 # Linting
 black               # Linter

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ black==24.8.0
     # via -r requirements-dev.in
 build==1.2.1
     # via pip-tools
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
 charset-normalizer==3.3.2
     # via requests
@@ -16,25 +16,19 @@ click==8.1.7
     # via
     #   black
     #   pip-tools
-colorama==0.4.6
-    # via
-    #   -r requirements.txt
-    #   build
-    #   click
-    #   pytest
 docutils==0.21.2
     # via flit
 exceptiongroup==1.2.2
     # via
     #   -r requirements.txt
     #   pytest
-flake8==7.1.0
+flake8==7.1.1
     # via -r requirements-dev.in
 flit==3.9.0
     # via -r requirements-dev.in
 flit-core==3.9.0
     # via flit
-idna==3.7
+idna==3.8
     # via requests
 iniconfig==2.0.0
     # via
@@ -46,7 +40,7 @@ isort==5.13.2
     # via -r requirements-dev.in
 mccabe==0.7.0
     # via flake8
-mypy==1.11.1
+mypy==1.11.2
     # via -r requirements-dev.in
 mypy-extensions==1.0.0
     # via
@@ -68,7 +62,7 @@ pluggy==1.5.0
     # via
     #   -r requirements.txt
     #   pytest
-pycodestyle==2.12.0
+pycodestyle==2.12.1
     # via flake8
 pyflakes==3.2.0
     # via flake8
@@ -82,8 +76,6 @@ pytest==8.3.2
     #   -r requirements.txt
 requests==2.32.3
     # via flit
-semantic-version==2.10.0
-    # via -r requirements-dev.in
 tomli==2.0.1
     # via
     #   -r requirements.txt
@@ -100,7 +92,7 @@ typing-extensions==4.12.2
     #   mypy
 urllib3==2.2.2
     # via requests
-wheel==0.43.0
+wheel==0.44.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile requirements.in
 #
-colorama==0.4.6
-    # via pytest
 exceptiongroup==1.2.2
     # via pytest
 iniconfig==2.0.0

--- a/tasks.py
+++ b/tasks.py
@@ -105,6 +105,23 @@ def _get_project_version() -> str:
     return list(versions.values())[0]
 
 
+def _get_next_version(current_version, part):
+    from packaging.version import Version
+
+    version = Version(str(current_version))
+
+    if part == 'major':
+        new_version = Version(f'{version.major + 1}.0.0')
+    elif part == 'minor':
+        new_version = Version(f'{version.major}.{version.minor + 1}.0')
+    elif part == 'patch':
+        new_version = Version(f'{version.major}.{version.minor}.{version.micro + 1}')
+    else:
+        raise ValueError('`part` must be "major", "minor", or "patch"')
+
+    return new_version
+
+
 def _update_project_version(version: str):
     pattern = re.compile('''^([ _]*version[ _]*[:=] *['"])(.*)(['"].*)$''', re.MULTILINE)
     for file in VERSION_FILES:
@@ -156,7 +173,7 @@ def build_version(c, version: str = '', bump: str = ''):
     """
     Updates the files that contain the project version to the new version.
     """
-    from semantic_version import Version
+    from packaging.version import Version
 
     v1 = Version(_get_project_version())
     if version and bump:
@@ -178,7 +195,7 @@ def build_version(c, version: str = '', bump: str = ''):
             raise Exit(f'New version `{v2}` needs to be greater than the existing version `{v1}`.')
     else:
         try:
-            v2 = getattr(v1, f'next_{bump.lower().strip()}')()
+            v2 = _get_next_version(v1, bump.strip().lower())
         except AttributeError:
             raise Exit('Invalid `bump` choice.')
 


### PR DESCRIPTION
Remove dependency on `semantic_version` package.

Using a small portion of its feature (getting the next version) that was easily replaced with a helper function.
Now using only `packaging.version.Version`, which is part of Python.